### PR TITLE
Corrige el flick del video en la pagina principal cuando se carga

### DIFF
--- a/app/assets/javascripts/landing.js
+++ b/app/assets/javascripts/landing.js
@@ -36,3 +36,7 @@ var markersArray = [];
       }
     }
   }
+
+$(document).ready(function (){
+    $(".content-video video").delay(2000).animate({opacity: 1}, 700);
+});

--- a/app/assets/stylesheets/components/_video.scss
+++ b/app/assets/stylesheets/components/_video.scss
@@ -2,10 +2,12 @@
   position: relative;
   text-align: center;
 
+
   video {
     width: 100%;
     position: relative;
     z-index: -1;
+    opacity: 0;
   }
 }
 


### PR DESCRIPTION
Cumple con:
  - [Eliminar el "flick" inicial del video al cargar el landing](https://www.pivotaltracker.com/story/show/107437226)