### PR TITLE
La barra de explorar ahora usa el 100% del ancho de la pantalla

### DIFF
--- a/app/views/layouts/_sub_navbar.html.haml
+++ b/app/views/layouts/_sub_navbar.html.haml
@@ -1,5 +1,5 @@
 %nav.sub-navbar.navbar.navbar-default
-  .container-fluid
+  .container
     .navbar-header
       %button.navbar-toggle.collapsed{ type: "button", 'data-toggle'=> "collapse", 'data-target'=> "#navbar", 'aria-expanded'=> "false", 'aria-controls'=> "navbar" }
         %span.sr-only Toggle navigation

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -16,9 +16,10 @@
     = disqus_init
   %body
     #main{:role => "main"}
-      .navigation.container
+      .navigation.container-fluid
         / <haml_loud> render &#39;layouts/navigation&#39; </haml_loud>
-        = render 'layouts/top_navbar'
+        .container
+          = render 'layouts/top_navbar'
         = render 'layouts/sub_navbar' unless current_page?(root_path)
 
       .container


### PR DESCRIPTION
Cumple con:
- [Barra de explorar con background con 100% de width](https://www.pivotaltracker.com/story/show/110003200)

![sociedad actua 100 barra explorar](https://cloud.githubusercontent.com/assets/660973/12482187/d7ff0f7c-c013-11e5-8753-0009fcb4f99f.png)
