### PR TITLE
Desactiva el scroll en los mapas para mejor navegación del sitio

### DIFF
--- a/app/assets/javascripts/landing.js
+++ b/app/assets/javascripts/landing.js
@@ -5,7 +5,7 @@ var markersArray = [];
 
       handler = Gmaps.build('Google');
       infowindow = new google.maps.InfoWindow();
-      handler.buildMap({ internal: {id: 'geolocation'} }, function(){
+      handler.buildMap({ provider: { scrollwheel: false}, internal: {id: 'geolocation'} }, function(){
         geocoder = new google.maps.Geocoder();
         if(navigator.geolocation){
           navigator.geolocation.getCurrentPosition(centerOnMap);

--- a/app/views/events/_form.html.haml
+++ b/app/views/events/_form.html.haml
@@ -51,7 +51,7 @@
   function loadMap(){
       handler = Gmaps.build('Google');
       infowindow = new google.maps.InfoWindow();
-      handler.buildMap({ internal: {id: 'mapa_evento'} }, function(){
+      handler.buildMap({provider: {scrollwheel: false}, internal: {id: 'mapa_evento'} }, function(){
         geocoder = new google.maps.Geocoder();
         user_has_location = #{raw @event.lat.nil?};
         if(user_has_location){

--- a/app/views/organizations/_map.html.haml
+++ b/app/views/organizations/_map.html.haml
@@ -22,7 +22,7 @@
       function loadMap(){
         handler = Gmaps.build('Google');
         infowindow = new google.maps.InfoWindow();
-        handler.buildMap({ internal: {id: 'geolocation'} }, function(){
+        handler.buildMap({provider: {scrollwheel: false}, internal: {id: 'geolocation'} }, function(){
           geocoder = new google.maps.Geocoder();
           if(navigator.geolocation){
             navigator.geolocation.getCurrentPosition(displayOnMap);

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -47,7 +47,7 @@
   function loadMap(){
       handler = Gmaps.build('Google');
       infowindow = new google.maps.InfoWindow();
-      handler.buildMap({ internal: {id: 'geolocation'} }, function(){
+      handler.buildMap({provider: {scrollwheel: false}, internal: {id: 'geolocation'} }, function(){
         geocoder = new google.maps.Geocoder();
         user_has_location = <%=@project.lat.nil?%>;
         if(user_has_location){

--- a/app/views/projects/_profile.html.haml
+++ b/app/views/projects/_profile.html.haml
@@ -66,7 +66,7 @@
   function loadMap(){
       handler = Gmaps.build('Google');
       infowindow = new google.maps.InfoWindow();
-      handler.buildMap({ internal: {id: 'geolocation'} }, function(){
+      handler.buildMap({provider: {scrollwheel: false}, internal: {id: 'geolocation'} }, function(){
         geocoder = new google.maps.Geocoder();
         user_has_location = #{@project.lat.nil?};
         if(user_has_location){


### PR DESCRIPTION
Cumple con:
- [Desactivar el zoom scroll de Google Maps del landing](https://www.pivotaltracker.com/story/show/109997608)