### PR TITLE
Elimina el espacio entre la barra de explorar y el contenedor principal

### DIFF
--- a/app/assets/stylesheets/components/_sub_navbar.scss
+++ b/app/assets/stylesheets/components/_sub_navbar.scss
@@ -6,7 +6,7 @@ nav.sub-navbar {
     20px,
     10px,
     10px,
-    25px,
+    0px,
     80px
   );
 


### PR DESCRIPTION
Cumple con:
- [Eliminar margen entre barra de Explorar y contenedor principal](https://www.pivotaltracker.com/story/show/110003040)

![sociedad actua cero separacion entre explorar y container principal](https://cloud.githubusercontent.com/assets/660973/12482402/e900ccd8-c014-11e5-80bd-59be3a9df7a2.png)
