### PR TITLE
Remove /assets/ on default_url logo uploader

### DIFF
--- a/app/uploaders/logo_uploader.rb
+++ b/app/uploaders/logo_uploader.rb
@@ -17,7 +17,7 @@ class LogoUploader < CarrierWave::Uploader::Base
   end
 
   def default_url(*args)
-    "/assets/placeholder/" + [model.class, "placeholder.png"].compact.join('_')
+    "placeholder/" + [model.class, "placeholder.png"].compact.join('_')
   end
   # Provide a default URL as a default if there hasn't been a file uploaded:
   # def default_url


### PR DESCRIPTION
En la nueva versión de sprockets ya no acepta "/assets/" lo que provocaba fallar.

Rails 4.2.3